### PR TITLE
Update init.vim

### DIFF
--- a/configs/init.vim
+++ b/configs/init.vim
@@ -597,8 +597,6 @@ augroup END
 " ----------------------------------------------------------------------------
 
 let g:airline_theme='onedark'
-let g:airline#extensions#tagbar#enabled = 1
-let g:airline#extensions#branch#enabled = 1
 let g:airline#extensions#tabline#enabled = 1
 let g:airline#extensions#tabline#formatter = 'unique_tail_improved'
 let g:airline_statusline_ontop=1


### PR DESCRIPTION
Remove these two settings because tagbar and branch extensions for airline are now enabled by default.