### PR TITLE
Add branch for git-extra-commands & fast-syntax-highlighting

### DIFF
--- a/configs/.zshrc
+++ b/configs/.zshrc
@@ -22,7 +22,7 @@ antigen bundle tmuxinator
 antigen bundle vi-mode
 
 antigen bundle agkozak/zsh-z
-antigen bundle zdharma/fast-syntax-highlighting
+antigen bundle zdharma/fast-syntax-highlighting --branch=main
 antigen bundle hschne/fzf-git
 antigen bundle leophys/zsh-plugin-fzf-finder
 antigen bundle zsh-users/zsh-history-substring-search
@@ -33,7 +33,7 @@ antigen bundle Tarrasch/zsh-bd
 antigen bundle djui/alias-tips
 antigen bundle adolfoabegg/browse-commit
 antigen bundle joel-porquet/zsh-dircolors-solarized
-antigen bundle unixorn/git-extra-commands
+antigen bundle unixorn/git-extra-commands --branch=main
 antigen bundle cal2195/q
 antigen bundle robertzk/send.zsh
 antigen bundle gko/ssh-connect


### PR DESCRIPTION
Due the changes based on the default branch naming need to improve an installation process

| Project | Default branch | Proof |
| ------- | -------------- | ----- |
| https://github.com/unixorn/git-extra-commands | main | <img width="1427" alt="image" src="https://user-images.githubusercontent.com/32175240/201199554-e0609002-7966-431c-aa85-f6063d2e066a.png"> |
| https://github.com/zdharma/fast-syntax-highlighting | main | <img width="1426" alt="image" src="https://user-images.githubusercontent.com/32175240/201199757-1130c2af-0c16-41e3-9aa0-b566be81cbd4.png"> |